### PR TITLE
Clarify only inbound sends require quorum

### DIFF
--- a/Rebroadcasting-Elections.md
+++ b/Rebroadcasting-Elections.md
@@ -12,23 +12,30 @@
 * Active transaction = a newly downloaded block to the node
 * Root = the account if the block is an open block otherwise the previous hash the block lists
 
-## New Blocks & Unchecked
+## New blocks & Unchecked
 There are several checks undergone when a new block is received by a node prior to it being committed to the ledger.
 A block is outright rejected and not moved to Unchecked if it has a bad signature or bad POW.
 A block will be moved to Unchecked if any of the following occur: a gap in the chain (either previous or source), a negative spend attempt, a block already received, an invalid balance, a fork, or an attempt to open the burn account.
-If the block is anything other than a send type, then it is committed to the ledger without requiring quorum.
-Quorum will only be required for the types of blocks other than send if a fork is detected at some point in the future. 
-If the block is a send type, then it is committed to the ledger as an active transaction.
+If the block is anything other than an inbound send, then it is committed to the ledger without requiring quorum.
+Quorum will only be required for the types of blocks other than inbound sends if a fork is detected at some point in the future. 
+If the block is an inbound send, then it is committed to the ledger as an active transaction.
 Now as an active transaction, it will be subject to announcement rounds.
 The only types of blocks in Unchecked that will also be subject to announcement rounds are forks.
+
+## New blocks in the future
+The core team will soon start working on "Active Graphs."
+This will require quorum on all blocks that enter the ledger as opposed to only inbound sends.
+The process will build a graph of possibile fork resolution outcomes on top of the ledger, in memory.
+The pre-built graph will be used to determine fork resolution if necessary.
+Given this is not implemented yet, the rest of the document explains the existing process where only inbound sends require quorum.
+
+#### Summarizing today's process - only inbound sends to your node and forks will be subject to announcement rounds and therefore election confirmation via quorum.
 
 ## Announcement Rounds
 Currently an announcement round lasts 16 seconds, although there is a proposal to reduce this to 4 seconds.
 During an announcement round, a loop occurs iterating through all roots within registered active transactions.
 If the root already exists on the ledger and has had election confirmation, then the block is removed from the active transaction list and stays committed to the ledger. 
 If the root is new or exists on the ledger but does not have election confirmation, then the broadcast-winner logic is run.
-
-#### Interpreting this in a different way - only send type blocks and forks will be subject to election confirmation.
 
 ## Broadcast-Winner & Elections
 Broadcast-winner includes the election process as well as republishing blocks if necessary. 
@@ -76,7 +83,7 @@ Therefore, regardless of your voting weight, you should consider the following p
 If you have < 0.1% voting weight, but will commit to the above, then running a node is worthwhile to further decentralize the network. 
 These points become even more critical as you amass voting weight or become a rebroadcasting account. 
 
-## Closing Thoughts
+## Closing thoughts
 Eventually the official representatives will be shut down and additional measures will be put in place to spread voting weight more easily. 
 Having existing, trustworthy, well maintained representative nodes will be critical as the voting weight is redistributed. 
 We will see those with < 0.1% grow to become rebroadcasting accounts over time. 
@@ -89,4 +96,5 @@ Nano’s vision to become truly decentralized cannot be realized without the com
 * https://nano.meltingice.net/network
 * https://github.com/nanocurrency/raiblocks/wiki/Representatives-and-decentralization
 * https://youtu.be/PgHUA8TGaXY
+* https://medium.com/@nanocurrency/developer-update-6-25-2018-73c7f44265fa
 * Community members on Discord including (but not limited to) @bbalaska, @cryptocode, @DESRT, @renesq

--- a/Rebroadcasting-Elections.md
+++ b/Rebroadcasting-Elections.md
@@ -16,7 +16,9 @@
 There are several checks undergone when a new block is received by a node prior to it being committed to the ledger.
 A block is outright rejected and not moved to Unchecked if it has a bad signature or bad POW.
 A block will be moved to Unchecked if any of the following occur: a gap in the chain (either previous or source), a negative spend attempt, a block already received, an invalid balance, a fork, or an attempt to open the burn account.
-If the block does not have these issues then it is committed to the ledger as an active transaction.
+If the block is anything other than a send type, then it is committed to the ledger without requiring quorum.
+Quorum will only be required for the types of blocks other than send if a fork is detected at some point in the future. 
+If the block is a send type, then it is committed to the ledger as an active transaction.
 Now as an active transaction, it will be subject to announcement rounds.
 The only types of blocks in Unchecked that will also be subject to announcement rounds are forks.
 
@@ -26,7 +28,7 @@ During an announcement round, a loop occurs iterating through all roots within r
 If the root already exists on the ledger and has had election confirmation, then the block is removed from the active transaction list and stays committed to the ledger. 
 If the root is new or exists on the ledger but does not have election confirmation, then the broadcast-winner logic is run.
 
-#### Interpreting this in a different way - all new blocks committed to the ledger will be subject to election confirmation based on the status of their roots.
+#### Interpreting this in a different way - only send type blocks and forks will be subject to election confirmation.
 
 ## Broadcast-Winner & Elections
 Broadcast-winner includes the election process as well as republishing blocks if necessary. 


### PR DESCRIPTION
Additionally, added information on Active Graphs for the future and cleaned up some formatting.